### PR TITLE
Move card column on pr

### DIFF
--- a/src/issuebranch/backends/github.py
+++ b/src/issuebranch/backends/github.py
@@ -293,6 +293,16 @@ class GithubSession(object):
 
         return full_url
 
+    def get_issue(self, issue_number):
+        full_url = self.get_full_url(
+            ISSUE_BACKEND_ENDPOINT,
+            owner=ISSUE_BACKEND_USER,
+            repo=ISSUE_BACKEND_REPO,
+            issue=issue_number
+        )
+
+        return self.request('get', full_url).json()
+
     def get_issues(self, **filters):
         """
         Returns all the issues in the user/repo values in the environment
@@ -462,14 +472,7 @@ class Backend(BaseBackend, GithubSession):
     @property
     @lru_cache()
     def issue(self):
-        full_url = self.get_full_url(
-            ISSUE_BACKEND_ENDPOINT,
-            owner=ISSUE_BACKEND_USER,
-            repo=ISSUE_BACKEND_REPO,
-            issue=self.issue_number
-        )
-
-        return self.request('get', full_url).json()
+        return self.get_issue(self.issue_number)
 
     def get_prefix(self, changetype=None):
         """

--- a/src/issuebranch/backends/github.py
+++ b/src/issuebranch/backends/github.py
@@ -246,7 +246,9 @@ class GithubSession(object):
 
         for column in self.get_columns(project):
             for card in self.get_cards(column):
-                if card['content_url'] == issue_url:
+                # use .get() here to prevent blowing up when encountering a note
+                # which does not contain a content_url key
+                if card.get('content_url') == issue_url:
                     return card
         else:
             raise CardError(f'Unable to find card for issue {issue_url}')

--- a/src/issuebranch/console_scripts.py
+++ b/src/issuebranch/console_scripts.py
@@ -501,7 +501,7 @@ def move_card_column(issue_number: int, column: str):
     try:
         issue_column(['issue_column', SCRUM_BOARD_NAME, issue_number, column])
     except:
-        print('Unable to move card to the active column, is it in triage?')
+        print('Unable to move card to the {} column, is it in triage?'.format(column))
 
 
 def projects():

--- a/src/issuebranch/console_scripts.py
+++ b/src/issuebranch/console_scripts.py
@@ -206,7 +206,7 @@ def make_branch(name, base):
     run_command('git checkout -b {} {}'.format(name, base))
 
 
-def make_pull_request(issue, upstream=None, empty_commit=True, move_card=True):
+def make_pull_request(issue, upstream=None, empty_commit=True, move_card=True, resolves_issue=True):
     """
     Injects an empty commit and opens a pull_request
 
@@ -230,8 +230,13 @@ def make_pull_request(issue, upstream=None, empty_commit=True, move_card=True):
 
     run_command(push_command)
 
+    if resolves_issue:
+        action = 'Resolves'
+    else:
+        action = 'Contributes to'
+
     # Open the actual pull request
-    message = '{}\n\nResolves {}/{}#{}'.format(subject, issue.owner, issue.repo, issue.issue_number)
+    message = '{}\n\n{} {}/{}#{}'.format(subject, action, issue.owner, issue.repo, issue.issue_number)
     run_command('hub pull-request -o -m "{}" --edit'.format(message), _fg=True)
 
     if move_card:

--- a/src/issuebranch/console_scripts.py
+++ b/src/issuebranch/console_scripts.py
@@ -206,7 +206,7 @@ def make_branch(name, base):
     run_command('git checkout -b {} {}'.format(name, base))
 
 
-def make_pull_request(issue, upstream=None, empty_commit=True):
+def make_pull_request(issue, upstream=None, empty_commit=True, move_card=True):
     """
     Injects an empty commit and opens a pull_request
     """
@@ -226,6 +226,9 @@ def make_pull_request(issue, upstream=None, empty_commit=True):
     # Open the actual pull request
     message = '{}\n\nResolves {}/{}#{}'.format(subject, issue.owner, issue.repo, issue.issue_number)
     run_command('hub pull-request -o -m "{}" --edit'.format(message), _fg=True)
+
+    if move_card:
+        move_card_column(issue.issue_number, 'feedback')
 
 
 def issue_branch():

--- a/src/issuebranch/console_scripts.py
+++ b/src/issuebranch/console_scripts.py
@@ -327,11 +327,7 @@ def make_issue_branch(args, issue):
 
         base = proc(*command_l[1:]).stdout.decode('utf8').strip()
 
-    # move this issue to the active column
-    try:
-        issue_column(['issue_column', SCRUM_BOARD_NAME, issue_number, 'active'])
-    except:
-        print('Unable to move card to the active column, is it in triage?')
+    move_card_column(issue_number, 'active')
 
     make_branch(slug, base)
 
@@ -488,6 +484,21 @@ def issue_show():
     issue_data = issue.issue
 
     print(json.dumps(issue_data, indent=4))
+
+
+def move_card_column(issue_number: int, column: str):
+    """
+    Moves the card for the given issue number to the specified column
+
+    Args:
+        issue_number: the issue's number
+        column: the name of the column
+    """
+    # move this issue to the active column
+    try:
+        issue_column(['issue_column', SCRUM_BOARD_NAME, issue_number, column])
+    except:
+        print('Unable to move card to the active column, is it in triage?')
 
 
 def projects():

--- a/src/issuebranch/console_scripts.py
+++ b/src/issuebranch/console_scripts.py
@@ -253,6 +253,14 @@ def issue_branch():
     parser.add_argument('--prefix', help='branch prefix, e.g. feature, bugfix, etc.')
     parser.add_argument('--pull-request', '--pr', action='store_true', help='open a pull request seeded with an empty commit')
     parser.add_argument('--upstream', '-u', help='the remote to push the branch for creating pull requests')
+    parser.add_argument(
+        '--no-resolves', action='store_false', dest='resolves',
+        help='used with pull request to indicate the PR does not close the issue'
+    )
+    parser.add_argument(
+        '--no-move-card', action='store_false', dest='move_card',
+        help='used with pull request to indicate the card on the Kanban Board should stay where it is'
+    )
     parser.add_argument('--subject', help='provide subject text instead of fetching')
     parser.add_argument('issue_number', type=int, nargs='?', help='the issue tracker\'s issue number')
 
@@ -295,7 +303,10 @@ def issue_branch():
         # presumably if the issue branch is already created, commits have been made
         empty_commit = not is_issue_branch
 
-        make_pull_request(issue, upstream=args.upstream, empty_commit=empty_commit)
+        make_pull_request(
+            issue, upstream=args.upstream, empty_commit=empty_commit,
+            resolves_issue=args.resolves, move_card=args.move_card
+        )
 
 
 def make_issue_branch(args, issue):
@@ -342,7 +353,8 @@ def make_issue_branch(args, issue):
 
         base = proc(*command_l[1:]).stdout.decode('utf8').strip()
 
-    move_card_column(issue_number, 'active')
+    if args.move_card:
+        move_card_column(issue_number, 'active')
 
     make_branch(slug, base)
 

--- a/src/issuebranch/console_scripts.py
+++ b/src/issuebranch/console_scripts.py
@@ -209,6 +209,13 @@ def make_branch(name, base):
 def make_pull_request(issue, upstream=None, empty_commit=True, move_card=True):
     """
     Injects an empty commit and opens a pull_request
+
+    Args:
+        issue: an issue object
+        upstream: the upstream to push the current branch to
+        empty_commit: whether to make a placeholder empty commit
+        move_card: whether to move the card on the Kanban Board
+        resolves_issue: when this PR is merged automatically close the referenced issue.
     """
     if empty_commit:
         run_command('git commit --allow-empty -m "Open Pull Request"')


### PR DESCRIPTION
When creating a branch for an issue using `issue-branch <issue_number>`, a pull request for that branch can then be created with:

```
issue-branch --pr -u <your fork name>
```

When this is run, a pull request is created with the issue's subject and initial content:

```
Resolves <user|org>/<repo>#<issue_number>
```

The `Resolves` keyword will automatically close the issue when the PR is merged.

Alternatively, `issue-branch --pr -u <your fork name> --no-resolves` can be used to leave the issue open, and the content is then

```
Contributes to <user|org>/<repo>#<issue_number>
```

Finally, `--no-move-card` can be used to leave the card in the project board where it is.